### PR TITLE
Fix: Set moduleResolution to 'bundler' for @sonolus/express compatibi…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     ],
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
This PR updates the `tsconfig.json` to use `moduleResolution: "bundler"`.
Without this setting, the project throws a TS2307 error when importing `@sonolus/express`, due to how the package uses modern `exports` fields.
This change allows the project to build and run correctly with TypeScript 5+.


TypeScriptのmoduleResolutionがデフォルトのままだと`@sonolus/express`が読み込めなかったため、"bundler"に変更しました。TypeScript 5以降ではこの指定が推奨されています。